### PR TITLE
Skip unavailable sensor (for DEFA eRange compability)

### DIFF
--- a/custom_components/defa_power/__init__.py
+++ b/custom_components/defa_power/__init__.py
@@ -52,6 +52,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: DefaPowerConfigEntry) ->
 
         c["coordinator"] = coordinator
         c["device"] = ChargePointDevice(chargepoint_data["chargepoint"], instance_id)
+        c["skipped_entities"] = []
 
         for alias, val in chargepoint_data["connectors"].items():
             connector_id = val["id"]
@@ -81,6 +82,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: DefaPowerConfigEntry) ->
             c["device"] = ConnectorDevice(val, instance_id, alias)
             c["alias"] = alias
             c["chargepoint_id"] = chargepoint_id
+            c["skipped_entities"] = []
 
             connectors[connector_id] = c
 

--- a/custom_components/defa_power/button.py
+++ b/custom_components/defa_power/button.py
@@ -55,14 +55,14 @@ DEFA_POWER_CONNECTOR_SENSOR_TYPES: tuple[
         key="start_charging",
         icon="mdi:flash",
         on_press=start_charging,
-        available_on_states=["EVConnected"],
+        available_on_states=["EVConnected", None],
         refresh_coordinator_wait=5,  # Start charging takes a while to update, waiting 5 seconds should be enough
     ),
     DefaPowerChargeStartStopButtonDescription(
         key="stop_charging",
         icon="mdi:flash-off",
         on_press=stop_charging,
-        available_on_states=["Charging", "SuspendedEV"],
+        available_on_states=["Charging", "SuspendedEV", None],
         refresh_coordinator_wait=1,  # Stop charging is faster, waiting 1 second should be enough
     ),
 )

--- a/custom_components/defa_power/models.py
+++ b/custom_components/defa_power/models.py
@@ -18,6 +18,7 @@ class RuntimeDataChargePoint(TypedDict):
 
     device: ChargePointDevice
     coordinator: CloudChargeChargepointCoordinator
+    skipped_entities: list[str]
 
 
 class RuntimeDataConnectorCapabilities(TypedDict):
@@ -35,6 +36,7 @@ class RuntimeDataConnector(TypedDict):
     eco_mode_coordinator: CloudChargeEcoModeCoordinator
     capabilities: RuntimeDataConnectorCapabilities
     chargepoint_id: str
+    skipped_entities: list[str]
 
 
 class RuntimeData(TypedDict):


### PR DESCRIPTION
This pull request introduces changes to improve the handling of entities in the `defa_power` integration by adding support for skipping entities with missing or `None` values. It also updates various entity descriptions and runtime data structures to enable this functionality. The most important changes are grouped below by theme.

### Entity Skipping Logic

* Added a `create_if_none` property to `DefaPowerConnectorNumberDescription` and `DefaPowerSensorDescription` to control whether entities should be created when their value is `None`. Entities with `create_if_none` set to `False` are now skipped during setup if their value is missing or `None`. [[1]](diffhunk://#diff-8193de21912ab1d293c6e857ab74f785c50894b5bcc69470b6a9a865cec28aaeR63) [[2]](diffhunk://#diff-ed566c05c64b3a209ec7cf6c0a73ee53b4f3392984cfab5d7482c1340155863dR99)
* Updated `async_setup_entry` methods in `number.py` and `sensor.py` to log skipped entities and append their keys to the `skipped_entities` list in runtime data when their value is `None`. [[1]](diffhunk://#diff-8193de21912ab1d293c6e857ab74f785c50894b5bcc69470b6a9a865cec28aaeR112-R124) [[2]](diffhunk://#diff-ed566c05c64b3a209ec7cf6c0a73ee53b4f3392984cfab5d7482c1340155863dL204-R249)

### Runtime Data Enhancements

* Added a `skipped_entities` field to `RuntimeDataChar
This pull request introduces enhancements to the `custom_components/defa_power` integration for Home Assistant, focusing on improved handling of entities with missing or `None` values. Key changes include adding a mechanism to skip the creation of such entities, updating data models to support this functionality, and extending the `available_on_states` property for buttons.

### Entity Skipping Mechanism
* [`custom_components/defa_power/models.py`](diffhunk://#diff-1c222c1ae306f00be9d545962cc5518edb0eea11b952d7e513bef50708b02db5R21): Added a `skipped_entities` field to `RuntimeDataChargePoint` and `RuntimeDataConnector` to track entities that are skipped during setup. [[1]](diffhunk://#diff-1c222c1ae306f00be9d545962cc5518edb0eea11b952d7e513bef50708b02db5R21) [[2]](diffhunk://#diff-1c222c1ae306f00be9d545962cc5518edb0eea11b952d7e513bef50708b02db5R39)
* [`custom_components/defa_power/number.py`](diffhunk://#diff-8193de21912ab1d293c6e857ab74f785c50894b5bcc69470b6a9a865cec28aaeR63): Introduced the `create_if_none` attribute in `DefaPowerConnectorNumberDescription`. Updated `async_setup_entry` to skip entities with `None` values and log the skipped entities. [[1]](diffhunk://#diff-8193de21912ab1d293c6e857ab74f785c50894b5bcc69470b6a9a865cec28aaeR63) [[2]](diffhunk://#diff-8193de21912ab1d293c6e857ab74f785c50894b5bcc69470b6a9a865cec28aaeR112-R124)
* [`custom_components/defa_power/sensor.py`](diffhunk://#diff-ed566c05c64b3a209ec7cf6c0a73ee53b4f3392984cfab5d7482c1340155863dR99): Added the `create_if_none` attribute to `DefaPowerSensorDescription`. Enhanced `async_setup_entry` to skip sensors with `None` values and log the skipped entities. [[1]](diffhunk://#diff-ed566c05c64b3a209ec7cf6c0a73ee53b4f3392984cfab5d7482c1340155863dR99) [[2]](diffhunk://#diff-ed566c05c64b3a209ec7cf6c0a73ee53b4f3392984cfab5d7482c1340155863dL204-R249)

### Data Model Updates
* [`custom_components/defa_power/__init__.py`](diffhunk://#diff-b3e50f017764b249f7917217a6d7cc6c4e584c90fbad11381e2e160223811d06R55): Initialized the `skipped_entities` list for both chargepoints and connectors during setup. [[1]](diffhunk://#diff-b3e50f017764b249f7917217a6d7cc6c4e584c90fbad11381e2e160223811d06R55) [[2]](diffhunk://#diff-b3e50f017764b249f7917217a6d7cc6c4e584c90fbad11381e2e160223811d06R85)

### Button Enhancements
* [`custom_components/defa_power/button.py`](diffhunk://#diff-b3ba286a4bf747393d42f4fde1a8bfef91668bf18a27d973d420595efa458edaL58-R65): Extended the `available_on_states` property for buttons to include `None`, allowing broader state compatibility.gePoint` and `RuntimeDataConnector` in `models.py` to track skipped entities for charge points and connectors. [[1]](diffhunk://#diff-1c222c1ae306f00be9d545962cc5518edb0eea11b952d7e513bef50708b02db5R21) [[2]](diffhunk://#diff-1c222c1ae306f00be9d545962cc5518edb0eea11b952d7e513bef50708b02db5R39)
* Initialized the `skipped_entities` list in the runtime data for both charge points and connectors during the setup process in `__init__.py`. [[1]](diffhunk://#diff-b3e50f017764b249f7917217a6d7cc6c4e584c90fbad11381e2e160223811d06R55) [[2]](diffhunk://#diff-b3e50f017764b249f7917217a6d7cc6c4e584c90fbad11381e2e160223811d06R85)

### Button Configuration Updates

* Updated `available_on_states` for `start_charging` and `stop_charging` buttons in `button.py` to include `None` as a valid state, allowing for broader compatibility with different states.