### PR TITLE
HomeAssistant 2025.12 deprecated fix

### DIFF
--- a/custom_components/defa_power/__init__.py
+++ b/custom_components/defa_power/__init__.py
@@ -4,6 +4,7 @@ import logging
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
 
 from .cloudcharge_api.client import CloudChargeAPIClient
 from .const import API_BASE_URL
@@ -87,6 +88,16 @@ async def async_setup_entry(hass: HomeAssistant, entry: DefaPowerConfigEntry) ->
             connectors[connector_id] = c
 
     entry.runtime_data = data
+
+    # Pre-register chargepoint devices in device registry to ensure
+    # they exist before connector devices try to reference them via via_device
+    device_registry = dr.async_get(hass)
+    for chargepoint_id, chargepoint_data in chargepoints.items():
+        device_info = chargepoint_data["device"].get_device_info()
+        # Ensure the parent device exists in device registry before child devices reference it
+        device_registry.async_get_or_create(
+            config_entry_id=entry.entry_id, **device_info
+        )
 
     entry.async_on_unload(entry.add_update_listener(update_listener))
 

--- a/custom_components/defa_power/config_flow.py
+++ b/custom_components/defa_power/config_flow.py
@@ -9,7 +9,7 @@ import uuid
 import voluptuous as vol
 
 from homeassistant import config_entries, core
-from homeassistant.data_entry_flow import FlowResult
+from homeassistant.config_entries import ConfigFlowResult
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.selector import (
     SelectSelector,
@@ -301,11 +301,10 @@ class DefaPowerOptionsFlowHandler(config_entries.OptionsFlow):
 
     def __init__(self, config_entry: config_entries.ConfigEntry) -> None:
         """Initialize options flow."""
-        self.config_entry = config_entry
 
     async def async_step_init(
         self, user_input: dict[str, Any] | None = None
-    ) -> FlowResult:
+    ) -> ConfigFlowResult:
         """Manage the options."""
         if user_input is not None:
             if user_input["select_step"] == "show_current_token":
@@ -316,7 +315,9 @@ class DefaPowerOptionsFlowHandler(config_entries.OptionsFlow):
             data_schema=OPTIONS_CHOICE_SCHEMA,
         )
 
-    async def async_step_show_token(self, user_input: dict[str, Any] | None = None):
+    async def async_step_show_token(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
         """Show the current token."""
         if user_input is not None:
             return await self.async_step_init()


### PR DESCRIPTION
Fixes deprecation warnings like:
Detected that custom integration 'defa_power' calls `device_registry.async_get_or_create` referencing a non existing `via_device` (...), with device info: {...} at custom_components/defa_power/switch.py, line 54: async_add_entities(entities, update_before_add=True). This will stop working in Home Assistant 2025.12.0, please create a bug report at https://github.com/Bebbssos/ha-defa-power/issues

Detected that custom integration 'defa_power' sets option flow config_entry explicitly, which is deprecated at custom_components/defa_power/config_flow.py, line 304: self.config_entry = config_entry. This will stop working in Home Assistant 2025.12, please create a bug report at https://github.com/Bebbssos/ha-defa-power/issues