### PR TITLE
Added dev container and AGENTS.md file

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,35 @@
+{
+  "name": "DEFA Power HA Dev",
+  "image": "ghcr.io/home-assistant/home-assistant:stable",
+  "workspaceMount": "source=${localWorkspaceFolder},target=/workspaces/ha-defa-power,type=bind,consistency=cached",
+  "workspaceFolder": "/workspaces/ha-defa-power",
+  "mounts": [
+    "source=${localWorkspaceFolder}/custom_components,target=/config/custom_components,type=bind,consistency=cached"
+  ],
+  "postCreateCommand": "bash /workspaces/ha-defa-power/.devcontainer/setup.sh",
+  "appPort": ["8123:8123", "5678:5678"],
+  // --userns=keep-id makes rootless Podman map your host user into the container
+  // so bind-mounted files remain owned by you. Docker ignores this flag.
+  "runArgs": ["--userns=keep-id", "--security-opt", "label=disable"],
+  "remoteUser": "root",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "ms-python.python",
+        "ms-python.debugpy",
+        "ms-python.vscode-pylance",
+        "charliermarsh.ruff"
+      ],
+      "settings": {
+        // Point VS Code at the Python that has homeassistant installed
+        "python.defaultInterpreterPath": "/usr/local/bin/python3",
+        "python.analysis.typeCheckingMode": "basic",
+        "python.analysis.extraPaths": [
+          "/usr/src/homeassistant"
+        ],
+        "editor.formatOnSave": true,
+        "files.trimTrailingWhitespace": true
+      }
+    }
+  }
+}

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -e
+
+CONFIG_DIR="/config"
+
+# Ensure the HA config directory exists
+mkdir -p "$CONFIG_DIR"
+
+# Write a minimal configuration.yaml if one doesn't exist yet
+if [ ! -f "$CONFIG_DIR/configuration.yaml" ]; then
+  cat > "$CONFIG_DIR/configuration.yaml" <<'EOF'
+# Minimal Home Assistant configuration for development
+default_config:
+
+# Enable the frontend
+frontend:
+
+# Logger – set defa_power to debug for development
+logger:
+  default: warning
+  logs:
+    custom_components.defa_power: debug
+EOF
+fi
+
+echo "Dev container setup complete."
+echo ""
+echo "To start Home Assistant:"
+echo "  Terminal:  hass -c /config"
+echo "  Debugger:  Press F5 in VS Code (Run > Start Debugging)"
+echo ""
+echo "Then open http://localhost:8123 in your browser."

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,17 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Home Assistant",
+      "type": "debugpy",
+      "request": "launch",
+      "module": "homeassistant",
+      "args": ["-c", "/config"],
+      "python": "/usr/local/bin/python3",
+      "justMyCode": false,
+      "env": {
+        "PYTHONASYNCIODEBUG": "1"
+      }
+    }
+  ]
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,57 @@
+# AGENTS.md
+
+## What this repo is
+
+Home Assistant custom integration for DEFA Power / eRange EV chargers. Distributed via HACS. Communicates with the CloudCharge API (`https://prod.cloudcharge.se/services/user`).
+
+## No local toolchain
+
+There is **no build system, no test runner, no linter, no formatter config** in this repo. No `pyproject.toml`, `Makefile`, `tox.ini`, or pre-commit hooks. All automated checks happen in CI only.
+
+To validate changes, push to GitHub — CI runs:
+1. **HACS validation** (`hacs/action@main`)
+2. **Hassfest** (`home-assistant/actions/hassfest@master`) — validates `manifest.json`, translations, and component structure
+
+There is no way to run these locally without installing the tools manually.
+
+## Dependencies
+
+`manifest.json` has `requirements: []`. All dependencies (`aiohttp`, `homeassistant`) are provided by the HA runtime. **Do not add packages to `requirements`** unless they are genuinely third-party and not bundled with HA.
+
+## Component directory
+
+All integration code lives in `custom_components/defa_power/`. This is the only directory that matters for the integration itself.
+
+## Architecture
+
+**Three coordinators** are created per connector:
+- `CloudChargeChargepointCoordinator` — polls every 15 min
+- `CloudChargeOperationalDataCoordinator` — polls every 60 s; drops to 10 s while `chargingState == "Charging"` and calls `async_start_live_consumption`
+- `CloudChargeEcoModeCoordinator` — only created if `capabilities.ecoMode == True`; uses a write-coalesce pattern via `set_data(callback)` that batches rapid writes then refreshes
+
+**Device hierarchy**: `ChargePointDevice` (parent) → `ConnectorDevice` (child, linked via `via_device`). Parent devices are registered before child devices — order matters.
+
+**Entity skipping**: Entities where `value_fn` returns `None` at setup and `create_if_none=False` (default) are intentionally omitted, not created as unavailable.
+
+## Key conventions
+
+- `unique_id` pattern: `{instance_id}_{chargepoint_or_connector_id}_{entity_key}`
+- Translation keys are prefixed with the domain: `defa_power_{entity_key}`
+- Both `en.json` and `sv.json` translations must be kept in sync — hassfest validates completeness
+- Config entry is `version=2, minor_version=1`; migration from v1 (`userId`/`token`) to v2 (`credentials: {user_id, token}`) exists in `__init__.py`
+- API auth uses headers `x-authorization` (token) and `x-user` (user_id)
+- Services target **connectors** (by `connector_alias`), not chargepoints — this is a common source of user confusion
+
+## Releases
+
+- HACS uses ZIP release: `hacs.json` sets `"zip_release": true`, `"filename": "defa_power.zip"`
+- The `upload_zip.yaml` workflow triggers on tag push and creates a **draft** release — drafts must be manually published
+- The ZIP must be named exactly `defa_power.zip`
+
+## Tests
+
+No tests exist. If adding them, use `pytest-homeassistant-custom-component`. The API client creates a new `aiohttp.ClientSession` per request, so calls are independently mockable.
+
+## API reference
+
+CloudCharge API swagger: `https://prod.cloudcharge.se/services/user/swagger.json`

--- a/README.md
+++ b/README.md
@@ -86,6 +86,23 @@ For complete documentation on available actions, please see [ACTIONS.md](ACTIONS
 
 - [ ] **Additional Entities**: Add more entities from the data provided by the CloudCharge API.
 
+### Development
+
+A dev container configuration is included for development in VS Code. It uses the official Home Assistant Docker image, so all HA packages are available for autocomplete and type checking.
+
+**Prerequisites:** [VS Code](https://code.visualstudio.com/) with the [Dev Containers extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers), and either Docker or Podman.
+
+1. Open the repository in VS Code.
+2. When prompted, click **Reopen in Container** (or run **Dev Containers: Reopen in Container** from the command palette).
+3. Once the container is ready, start Home Assistant:
+   - **Terminal:** `hass -c /config`
+   - **Debugger:** Press `F5` — breakpoints in the integration code will be hit.
+4. Open `http://localhost:8123` in your browser and add the DEFA Power integration.
+
+The `custom_components/defa_power` folder is bind-mounted directly into the container, so changes are reflected immediately without rebuilding.
+
+> **Podman users:** Set `"dev.containers.dockerPath": "podman"` in your VS Code user settings.
+
 ### Disclaimer
 
 - _This project is not affiliated with, endorsed, or supported by DEFA AS._


### PR DESCRIPTION
**Development environment setup:**

* Added `.devcontainer/devcontainer.json` to define a VS Code Dev Container using the official Home Assistant Docker image, with bind mounts for the workspace and custom components, port mappings, recommended extensions, and Python settings for type checking and formatting.
* Added `.devcontainer/setup.sh` script to initialize the `/config` directory and create a minimal `configuration.yaml` for Home Assistant if it does not exist.
* Added `.vscode/launch.json` to provide a ready-to-use debug configuration for Home Assistant using `debugpy`, enabling breakpoints and debugging from VS Code.
* Updated `README.md` with instructions for using the dev container, including prerequisites, setup steps, and notes for Docker/Podman users.

**Developer documentation for coding agents:**

* Added `AGENTS.md` with a comprehensive overview of the repository’s architecture, conventions, dependency management, release process, and development practices, clarifying how to contribute and what tools are (and are not) provided locally.