### PR TITLE
Potential fix for "No loginAttempts found" error

### DIFF
--- a/custom_components/defa_power/cloudcharge_api/client.py
+++ b/custom_components/defa_power/cloudcharge_api/client.py
@@ -53,6 +53,14 @@ class CloudChargeAPIClient:
         """Yield a shared session reused across requests via HTTP keep-alive.
 
         Enforces a minimum interval between outgoing requests.
+
+        The API runs on several servers, and a cookie (INGRESSCOOKIE) decides
+        which one a request reaches. The shared cookie jar keeps sending that
+        cookie back, so every request stays on the same server. Some state
+        appears to only exist on the server that created it, so a session per
+        request would spread calls around: /login reports "No loginAttempts
+        found" when it reaches a different server than the /prelogin that sent
+        the SMS.
         """
         async with self.__request_lock:
             elapsed = time.monotonic() - self.__last_request_time

--- a/custom_components/defa_power/config_flow.py
+++ b/custom_components/defa_power/config_flow.py
@@ -118,7 +118,26 @@ class DefaPowerConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     VERSION = 2
     MINOR_VERSION = 1
 
-    send_code_data: dict[str, Any] | None
+    send_code_data: dict[str, Any] | None = None
+    # The API runs on several servers, and the login attempt created by
+    # /prelogin appears to only exist on the server that handled it. All steps
+    # share one client so its cookie jar keeps them on that server, otherwise
+    # /login fails with "No loginAttempts found".
+    client: CloudChargeAPIClient | None = None
+
+    def __get_client(self) -> CloudChargeAPIClient:
+        """Return the client shared by all steps of this flow."""
+        if self.client is None:
+            self.client = CloudChargeAPIClient(API_BASE_URL)
+        return self.client
+
+    @core.callback
+    def async_remove(self) -> None:
+        """Clean up when the flow is removed."""
+        if self.client is not None:
+            client = self.client
+            self.client = None
+            self.hass.async_create_task(client.async_close())
 
     async def async_step_user(self, user_input: dict[str, Any] | None = None):
         """Handle the initial step."""
@@ -161,7 +180,7 @@ class DefaPowerConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 user_input[CONF_PHONE_NUMBER] = normalize_phone_number(
                     user_input[CONF_PHONE_NUMBER]
                 )
-                client = CloudChargeAPIClient(API_BASE_URL)
+                client = self.__get_client()
                 match user_input[CONF_DEV_TOKEN_OPTIONS]:
                     case "cloud_charge":
                         dev_token = "X5zVn6MCWvrf6ft2"
@@ -209,11 +228,11 @@ class DefaPowerConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         if user_input is not None:
             # Validate the path.
             data = {}
-            if self.send_code_data is None:
+            if self.send_code_data is None or self.client is None:
                 _LOGGER.error("SMS code step reached without prior send_code_data")
                 return await self.async_step_send_code()
             try:
-                client = CloudChargeAPIClient(API_BASE_URL)
+                client = self.client
                 await client.async_login_with_phone_number(
                     self.send_code_data["phone_number"],
                     user_input[CONF_SMS_CODE],
@@ -262,7 +281,7 @@ class DefaPowerConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             token = user_input[CONF_TOKEN]
             data = {}
             try:
-                client = CloudChargeAPIClient(API_BASE_URL)
+                client = self.__get_client()
                 await client.async_login_with_token(user_id, token)
                 data["credentials"] = client.export_credentials()
             except CloudChargeAuthError as e:


### PR DESCRIPTION
## Summary
- Fixes #23
- API runs behind multiple servers, and a login attempt created by `/prelogin` only exists on the server that handled it
- Config flow was creating a new `CloudChargeAPIClient` (and thus a fresh cookie jar) at each step, so requests could land on a different server and lose the session, causing `Forbidden No loginAttempts found error: No loginAttempts found`
- Now reuses a single client for the whole flow so its cookies keep every step pinned to the same server, plus cleans up the client on flow removal