### PR TITLE
Fixed some entities showing as unavailable in HA 2026.9.0

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,10 +4,15 @@
   "workspaceMount": "source=${localWorkspaceFolder},target=/workspaces/ha-defa-power,type=bind,consistency=cached",
   "workspaceFolder": "/workspaces/ha-defa-power",
   "mounts": [
-    "source=${localWorkspaceFolder}/custom_components,target=/config/custom_components,type=bind,consistency=cached"
+    "source=${localWorkspaceFolder}/custom_components,target=/config/custom_components,type=bind,consistency=cached",
+    "source=ha-defa-power-config,target=/config,type=volume",
+    "source=ha-defa-power-claude,target=/root/.claude,type=volume"
   ],
   "postCreateCommand": "bash /workspaces/ha-defa-power/.devcontainer/setup.sh",
-  "appPort": ["8123:8123", "5678:5678"],
+  "appPort": [
+    "8123:8123",
+    "5678:5678"
+  ],
   "remoteUser": "root",
   "customizations": {
     "vscode": {

--- a/.gitignore
+++ b/.gitignore
@@ -160,3 +160,6 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+# Claude Code
+.claude/settings.local.json

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,7 +29,7 @@ All integration code lives in `custom_components/defa_power/`. This is the only 
 - `CloudChargeOperationalDataCoordinator` — polls every 60 s; drops to 10 s while `chargingState == "Charging"` and calls `async_start_live_consumption`
 - `CloudChargeEcoModeCoordinator` — only created if `capabilities.ecoMode == True`; uses a write-coalesce pattern via `set_data(callback)` that batches rapid writes then refreshes
 
-**Device hierarchy**: `ChargePointDevice` (parent) → `ConnectorDevice` (child, linked via `via_device`). Parent devices are registered before child devices — order matters.
+**Device hierarchy**: `ChargePointDevice` (parent) → `ConnectorDevice` (child, linked via `via_device_id`). Each chargepoint is registered in the device registry in `async_setup_entry` before its connectors are built, and the resulting device entry id is passed to `ConnectorDevice` — order matters. (`via_device` is deprecated and raises in HA 2026.9+ when the deprecation report cannot find an integration frame.)
 
 **Entity skipping**: Entities where `value_fn` returns `None` at setup and `create_if_none=False` (default) are intentionally omitted, not created as unavailable.
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ This is a custom integration for Home Assistant that allows you to control and m
 
 - **DEFA Power chargers**: Full support for all features.
 - **DEFA eRange chargers**: Partial support - some features may not be available or may not function as expected on these models.
+- **Home Assistant**: 2026.8.0 or newer. Older versions can keep using version 0.5.4.
 
 ### Installation Instructions
 

--- a/custom_components/defa_power/__init__.py
+++ b/custom_components/defa_power/__init__.py
@@ -47,6 +47,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: DefaPowerConfigEntry) ->
     chargepoint_ids = await client.async_get_chargepoint_ids()
 
     instance_id = entry.data.get("instance_id") or "default"
+    device_registry = dr.async_get(hass)
     chargepoints = {}
     connectors = {}
     data: RuntimeData = {
@@ -60,9 +61,18 @@ async def async_setup_entry(hass: HomeAssistant, entry: DefaPowerConfigEntry) ->
         await coordinator.async_config_entry_first_refresh()
         chargepoint_data = coordinator.data
 
+        chargepoint_device = ChargePointDevice(
+            chargepoint_data["chargepoint"], instance_id
+        )
+        # Register the chargepoint device up front so its connectors can reference
+        # it by device id (via_device_id)
+        chargepoint_device_entry = device_registry.async_get_or_create(
+            config_entry_id=entry.entry_id, **chargepoint_device.get_device_info()
+        )
+
         cp: RuntimeDataChargePoint = {
             "coordinator": coordinator,
-            "device": ChargePointDevice(chargepoint_data["chargepoint"], instance_id),
+            "device": chargepoint_device,
             "skipped_entities": [],
         }
         chargepoints[chargepoint_id] = cp
@@ -113,7 +123,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: DefaPowerConfigEntry) ->
                     )
 
             conn: RuntimeDataConnector = {
-                "device": ConnectorDevice(val, instance_id, alias),
+                "device": ConnectorDevice(
+                    val, instance_id, alias, chargepoint_device_entry.id
+                ),
                 "alias": alias,
                 "chargepoint_id": chargepoint_id,
                 "operational_data_coordinator": operational_data_coordinator,
@@ -126,16 +138,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: DefaPowerConfigEntry) ->
             connectors[connector_id] = conn
 
     entry.runtime_data = data
-
-    # Pre-register chargepoint devices in device registry to ensure
-    # they exist before connector devices try to reference them via via_device
-    device_registry = dr.async_get(hass)
-    for chargepoint_id, chargepoint_data in chargepoints.items():
-        device_info = chargepoint_data["device"].get_device_info()
-        # Ensure the parent device exists in device registry before child devices reference it
-        device_registry.async_get_or_create(
-            config_entry_id=entry.entry_id, **device_info
-        )
 
     entry.async_on_unload(entry.add_update_listener(update_listener))
 

--- a/custom_components/defa_power/coordinator.py
+++ b/custom_components/defa_power/coordinator.py
@@ -66,12 +66,7 @@ class CloudChargeChargepointCoordinator(DataUpdateCoordinator):
             except CloudChargeAPIError as err:
                 raise UpdateFailed(f"Error communicating with API: {err}") from err
 
-            connectors = {}
-            chargepoint_id = chargepoint.get("id", "")
-
-            for alias, connector in (chargepoint.get("aliasMap") or {}).items():
-                connector["chargepoint_id"] = chargepoint_id  # type: ignore[literal-required]
-                connectors[alias] = connector
+            connectors = dict(chargepoint.get("aliasMap") or {})
 
             return {"chargepoint": chargepoint, "connectors": connectors}
 

--- a/custom_components/defa_power/devices.py
+++ b/custom_components/defa_power/devices.py
@@ -23,7 +23,7 @@ class ChargePointDevice:
 class ConnectorDevice:
     """Representation of a DEFA Power connector device."""
 
-    def __init__(self, data, instance_id, alias) -> None:
+    def __init__(self, data, instance_id, alias, via_device_id: str) -> None:
         """Initialize the device."""
         self._device_info = DeviceInfo(
             identifiers={(DOMAIN, instance_id, data["id"])},  # type: ignore[arg-type]
@@ -32,7 +32,7 @@ class ConnectorDevice:
             name=data.get("displayName") or alias or data["id"],
             sw_version=data["firmwareVersion"],
             serial_number=data["serialNumber"],
-            via_device=(DOMAIN, instance_id, data["chargepoint_id"]),  # type: ignore[arg-type]
+            via_device_id=via_device_id,
         )
 
     def get_device_info(self):

--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,6 @@
 {
   "filename": "defa_power.zip",
+  "homeassistant": "2026.8.0",
   "name": "DEFA Power",
   "zip_release": true
 }


### PR DESCRIPTION
## Problem

On HA 2026.9 several platforms fail to add their entities, which then show as unavailable:

```
ERROR ... Error adding entity None for domain sensor with platform defa_power
RuntimeError: Detected code that calls `device_registry.async_get_or_create` with a
deprecated `via_device` parameter; use `via_device_id` instead.
```

Which platforms break varies per restart.

## Cause

`ConnectorDevice` used `via_device=(DOMAIN, instance_id, chargepoint_id)`. `via_device` was
deprecated in 2026.8 and should only warn until 2027.8 — but HA reports it via
`frame.report_usage`, which walks the stack for the integration's frame. Our `DeviceInfo` is
consumed inside `entity_platform`, so often no `defa_power` frame is left, and the warning is
raised as a `RuntimeError` instead. Stack timing is why it looked intermittent.

## Fix

Link connectors by device id: each charge point is registered in the device registry inside
the setup loop, and its `DeviceEntry.id` is passed to `ConnectorDevice` as `via_device_id`.
The old post-loop pre-registration block is no longer needed.

## Upgrade impact

No migration; nothing is recreated. The registry already stored the resolved `via_device_id`
internally and charge point identifiers are unchanged, so devices, entity ids and history are
preserved.

Minimum HA is now **2026.8.0** — `DeviceInfo["via_device_id"]` doesn't exist before that.
`hacs.json` declares this, so older installs simply stay on 0.5.4 (which still works there).

## Also

- Removed a now-dead `connector["chargepoint_id"]` injection in the chargepoint coordinator —
  its only consumer was the `via_device` tuple removed above.
- Updated `AGENTS.md`; added `.claude/settings.local.json` to `.gitignore`.